### PR TITLE
Fix navbar scroll listener

### DIFF
--- a/src/hooks/useNavbarState.ts
+++ b/src/hooks/useNavbarState.ts
@@ -1,22 +1,24 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 export const useNavbarState = () => {
   const [prevScrollPos, setPrevScrollPos] = useState(0);
+  const prevScrollPosRef = useRef(0);
   const [visible, setVisible] = useState(true);
   const [atTop, setAtTop] = useState(true);
 
   useEffect(() => {
     const handleScroll = () => {
       const currentScrollPos = window.scrollY;
-      
-      setVisible(prevScrollPos > currentScrollPos || currentScrollPos < 10);
+
+      setVisible(prevScrollPosRef.current > currentScrollPos || currentScrollPos < 10);
       setAtTop(currentScrollPos <= 10);
+      prevScrollPosRef.current = currentScrollPos;
       setPrevScrollPos(currentScrollPos);
     };
 
     window.addEventListener('scroll', handleScroll, { passive: true });
     return () => window.removeEventListener('scroll', handleScroll);
-  }, [prevScrollPos]);
+  }, []);
 
   return { visible, atTop, prevScrollPos };
 };


### PR DESCRIPTION
## Summary
- fix navbar scroll state hook to avoid reattaching the listener on every scroll

## Testing
- `npm run build` *(fails: Cannot find module 'prismjs/components/prism-css' ...)*

------
https://chatgpt.com/codex/tasks/task_e_6842f91886248321adae5e5fedf290b4